### PR TITLE
Fix property typo in AuthController

### DIFF
--- a/src/modules/api/core/auth/auth.controller.ts
+++ b/src/modules/api/core/auth/auth.controller.ts
@@ -44,7 +44,7 @@ export class AuthController {
   constructor(
     private authService: AuthService,
     private usersService: UsersService,
-    private refreshToeknService: RefreshTokenService,
+    private refreshTokenService: RefreshTokenService,
   ) {}
 
   @Public()
@@ -107,7 +107,7 @@ export class AuthController {
     const userPayload = req.user as IAuthenticatedUser;
 
     const { accessToken, refreshToken } =
-      await this.refreshToeknService.generateTokenPair(
+      await this.refreshTokenService.generateTokenPair(
         userPayload.sub,
         userPayload,
         req.cookies['refreshToken'],


### PR DESCRIPTION
## Summary
- rename AuthController's `refreshToeknService` to `refreshTokenService`
- update usage in `googleAuthCallback`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c49a81980832da2c5d98ce1253fe3